### PR TITLE
fix: make the waterlogging processor work on 1.19

### DIFF
--- a/common/src/main/java/dev/ftb/packcompanion/features/waterlogging/WaterLoggingFixProcessor.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/waterlogging/WaterLoggingFixProcessor.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import dev.ftb.packcompanion.registry.StructureProcessorRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -11,6 +12,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlac
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
 
 public class WaterLoggingFixProcessor extends StructureProcessor {
@@ -20,15 +22,15 @@ public class WaterLoggingFixProcessor extends StructureProcessor {
     @Nullable
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader, BlockPos blockPos, BlockPos blockPos2, StructureTemplate.StructureBlockInfo original, StructureTemplate.StructureBlockInfo after, StructurePlaceSettings structurePlaceSettings) {
-        if (after.state.isAir()) {
+        if (after.state.isAir() || !(levelReader instanceof WorldGenRegion worldGenRegion)) {
             return after;
         }
 
         // Is the block meant to be a fluid? No then lets make sure the world doesn't already have a fluid there
         if (after.state.getFluidState().isEmpty()) {
             // Is the block water? No, is the current block in the world water? Yes, Cool, remove it before placement
-            if (after.state.getBlock() != Blocks.WATER && levelReader.getBlockState(after.pos).getBlock() == Blocks.WATER) {
-                ((WorldGenRegion) levelReader).setBlock(after.pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+            if (after.state.getBlock() != Blocks.WATER && levelReader.getBlockState(after.pos).getFluidState().is(Fluids.WATER)) {
+                worldGenRegion.setBlock(after.pos, after.state, Block.UPDATE_ALL);
             }
         }
 


### PR DESCRIPTION
Check the in-world block's fluidstate material rather than the in-world block itself And where a change is needed, set it to the processor's intended state, not simply air.