### PR TITLE
Feature/respawnable spawners

### DIFF
--- a/common/src/main/java/dev/ftb/packcompanion/CommandRegistry.java
+++ b/common/src/main/java/dev/ftb/packcompanion/CommandRegistry.java
@@ -3,7 +3,7 @@ package dev.ftb.packcompanion;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import dev.ftb.packcompanion.commands.CommandEntry;
-import dev.ftb.packcompanion.commands.LootTableGeneratorCommand;
+import dev.ftb.packcompanion.commands.SpawnerManagerClearCommand;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -12,16 +12,17 @@ import java.util.Set;
 
 public class CommandRegistry {
     private static final Set<CommandEntry> COMMANDS = Set.of(
-        new LootTableGeneratorCommand()
+//        new LootTableGeneratorCommand()
+        new SpawnerManagerClearCommand()
     );
 
     public static void setup(CommandDispatcher<CommandSourceStack> commandDispatcher, CommandBuildContext commandBuildContext, Commands.CommandSelection commandSelection) {
-//        LiteralArgumentBuilder<CommandSourceStack> companionRootCommand = Commands.literal(PackCompanion.MOD_ID);
+        LiteralArgumentBuilder<CommandSourceStack> companionRootCommand = Commands.literal(PackCompanion.MOD_ID);
 
-//        for (CommandEntry command : COMMANDS) {
-//            companionRootCommand.then(command.register());
-//        }
+        for (CommandEntry command : COMMANDS) {
+            companionRootCommand.then(command.register());
+        }
 
-//        commandDispatcher.register(companionRootCommand);
+        commandDispatcher.register(companionRootCommand);
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/PackCompanion.java
+++ b/common/src/main/java/dev/ftb/packcompanion/PackCompanion.java
@@ -1,6 +1,5 @@
 package dev.ftb.packcompanion;
 
-import dev.architectury.event.events.client.ClientLifecycleEvent;
 import dev.architectury.event.events.common.CommandRegistrationEvent;
 import dev.architectury.event.events.common.LifecycleEvent;
 import dev.architectury.registry.ReloadListenerRegistry;
@@ -8,6 +7,7 @@ import dev.architectury.utils.Env;
 import dev.architectury.utils.EnvExecutor;
 import dev.ftb.packcompanion.config.PCCommonConfig;
 import dev.ftb.packcompanion.config.PCServerConfig;
+import dev.ftb.packcompanion.features.spawners.SpawnerManager;
 import dev.ftb.packcompanion.registry.LootTableRegistries;
 import dev.ftb.packcompanion.registry.ReloadResourceManager;
 import dev.ftb.packcompanion.registry.StructureProcessorRegistry;
@@ -28,6 +28,7 @@ public class PackCompanion {
         CommandRegistrationEvent.EVENT.register(CommandRegistry::setup);
 
         LifecycleEvent.SERVER_BEFORE_START.register(PackCompanion::serverBeforeStart);
+        LifecycleEvent.SERVER_STARTED.register(PackCompanion::serverStarted);
         LifecycleEvent.SETUP.register(PackCompanion::onSetup);
 
         EnvExecutor.runInEnv(Env.CLIENT, () -> PackCompanionClient::init);
@@ -39,5 +40,11 @@ public class PackCompanion {
 
     private static void serverBeforeStart(MinecraftServer server) {
         PCServerConfig.load(server);
+    }
+
+    private static void serverStarted(MinecraftServer server) {
+        if (PCServerConfig.SPAWNERS_ALLOW_RESPAWN.get()) {
+            SpawnerManager.get().init(server);
+        }
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/PackCompanion.java
+++ b/common/src/main/java/dev/ftb/packcompanion/PackCompanion.java
@@ -7,6 +7,9 @@ import dev.architectury.utils.Env;
 import dev.architectury.utils.EnvExecutor;
 import dev.ftb.packcompanion.config.PCCommonConfig;
 import dev.ftb.packcompanion.config.PCServerConfig;
+import dev.ftb.packcompanion.features.CommonFeature;
+import dev.ftb.packcompanion.features.Features;
+import dev.ftb.packcompanion.features.ServerFeature;
 import dev.ftb.packcompanion.features.spawners.SpawnerManager;
 import dev.ftb.packcompanion.registry.LootTableRegistries;
 import dev.ftb.packcompanion.registry.ReloadResourceManager;
@@ -36,6 +39,7 @@ public class PackCompanion {
 
     private static void onSetup() {
         PCCommonConfig.load();
+        Features.INSTANCE.getCommonFeatures().forEach(CommonFeature::setup);
     }
 
     private static void serverBeforeStart(MinecraftServer server) {
@@ -43,8 +47,6 @@ public class PackCompanion {
     }
 
     private static void serverStarted(MinecraftServer server) {
-        if (PCServerConfig.SPAWNERS_ALLOW_RESPAWN.get()) {
-            SpawnerManager.get().init(server);
-        }
+        Features.INSTANCE.getServerFeatures().forEach(e -> e.setup(server));
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
+++ b/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
@@ -18,9 +18,10 @@ public class SpawnerManagerClearCommand implements CommandEntry {
     private int clear(CommandContext<CommandSourceStack> context) {
         SpawnerManager.DataStore dataStore = SpawnerManager.get().getDataStore();
         var spawners = Objects.requireNonNull(dataStore).getBrokenSpawners();
+        int cleared = spawners.size();
         dataStore.getBrokenSpawners().clear();
         dataStore.setDirty();
-        context.getSource().sendSuccess(Component.literal(spawners.size() + " broken spawners cleared"), false);
+        context.getSource().sendSuccess(Component.literal(cleared + " broken spawners cleared"), false);
         return 0;
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
+++ b/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
@@ -14,7 +14,7 @@ public class SpawnerManagerClearCommand implements CommandEntry {
     }
 
     private int clear(CommandContext<CommandSourceStack> context) {
-        SpawnerManager.DataStore dataStore = SpawnerManager.get().getDataStore(context.getSource().getServer());
+        SpawnerManager.DataStore dataStore = SpawnerManager.get().getDataStore();
         var spawners = dataStore.getBrokenSpawners();
         dataStore.getBrokenSpawners().clear();
         dataStore.setDirty();

--- a/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
+++ b/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
@@ -7,6 +7,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 
+import java.util.Objects;
+
 public class SpawnerManagerClearCommand implements CommandEntry {
     @Override
     public LiteralArgumentBuilder<CommandSourceStack> register() {
@@ -15,7 +17,7 @@ public class SpawnerManagerClearCommand implements CommandEntry {
 
     private int clear(CommandContext<CommandSourceStack> context) {
         SpawnerManager.DataStore dataStore = SpawnerManager.get().getDataStore();
-        var spawners = dataStore.getBrokenSpawners();
+        var spawners = Objects.requireNonNull(dataStore).getBrokenSpawners();
         dataStore.getBrokenSpawners().clear();
         dataStore.setDirty();
         context.getSource().sendSuccess(Component.literal(spawners.size() + " broken spawners cleared"), false);

--- a/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
+++ b/common/src/main/java/dev/ftb/packcompanion/commands/SpawnerManagerClearCommand.java
@@ -1,0 +1,24 @@
+package dev.ftb.packcompanion.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import dev.ftb.packcompanion.features.spawners.SpawnerManager;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+public class SpawnerManagerClearCommand implements CommandEntry {
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> register() {
+        return Commands.literal("spawner_manager").then(Commands.literal("clear").executes(this::clear));
+    }
+
+    private int clear(CommandContext<CommandSourceStack> context) {
+        SpawnerManager.DataStore dataStore = SpawnerManager.get().getDataStore(context.getSource().getServer());
+        var spawners = dataStore.getBrokenSpawners();
+        dataStore.getBrokenSpawners().clear();
+        dataStore.setDirty();
+        context.getSource().sendSuccess(Component.literal(spawners.size() + " broken spawners cleared"), false);
+        return 0;
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -15,7 +15,7 @@ public interface PCServerConfig {
             .comment("When enabled, broken spawner blocks will be remembered and will respawn at a given interval.");
 
     IntValue SPAWNERS_RESPAWN_INTERVAL = SPAWNERS.getInt("respawn_interval", 60, 0, 24 * 60)
-            .comment("The interval in minutes at which spawners will respawn. Set to 0 to disable.");
+            .comment("The interval in minutes at which spawners will respawn.");
 
     StringListValue SPAWNERS_USE_RANDOM_ENTITY = SPAWNERS.getStringList("random_entity", new ArrayList<>())
             .comment("A list of entity types that will be used to replace broken spawners. Set to an empty list to disable.");

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -1,14 +1,26 @@
 package dev.ftb.packcompanion.config;
 
-import dev.ftb.mods.ftblibrary.snbt.config.SNBTConfig;
+import dev.ftb.mods.ftblibrary.snbt.config.*;
 import dev.ftb.packcompanion.PackCompanion;
 import net.minecraft.server.MinecraftServer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public interface PCServerConfig {
     SNBTConfig CONFIG = SNBTConfig.create(PackCompanion.MOD_ID + "-server");
 
+    SNBTConfig SPAWNERS = CONFIG.getGroup("spawners");
+    BooleanValue SPAWNERS_ALLOW_RESPAWN = SPAWNERS.getBoolean("allow_respawn", false)
+            .comment("When enabled, broken spawner blocks will be remembered and will respawn at a given interval.");
+
+    IntValue SPAWNERS_RESPAWN_INTERVAL = SPAWNERS.getInt("respawn_interval", 60, 0, 24 * 60)
+            .comment("The interval in minutes at which spawners will respawn. Set to 0 to disable.");
+
+    StringListValue SPAWNERS_USE_RANDOM_ENTITY = SPAWNERS.getStringList("random_entity", new ArrayList<>())
+            .comment("A list of entity types that will be used to replace broken spawners. Set to an empty list to disable.");
+
     static void load(MinecraftServer server) {
-        // Not needed right now
-        //ConfigUtil.loadDefaulted(CONFIG, server.getWorldPath(ConfigUtil.SERVER_CONFIG_DIR), PackCompanion.MOD_ID);
+        ConfigUtil.loadDefaulted(CONFIG, server.getWorldPath(ConfigUtil.SERVER_CONFIG_DIR), PackCompanion.MOD_ID);
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -20,6 +20,9 @@ public interface PCServerConfig {
     StringListValue SPAWNERS_USE_RANDOM_ENTITY = SPAWNERS.getStringList("random_entity", new ArrayList<>())
             .comment("A list of entity types that will be used to replace broken spawners. Set to an empty list to disable.");
 
+    DoubleValue MODIFY_MOB_BASE_HEALTH = CONFIG.getDouble("modify_mob_base_health", 0D, 0D, 1000D)
+            .comment("If non-zero, set the base health of all mobs to be multiplied by this value. Set to 0 to disable.");
+
     static void load(MinecraftServer server) {
         ConfigUtil.loadDefaulted(CONFIG, server.getWorldPath(ConfigUtil.SERVER_CONFIG_DIR), PackCompanion.MOD_ID);
     }

--- a/common/src/main/java/dev/ftb/packcompanion/features/CommonFeature.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/CommonFeature.java
@@ -2,7 +2,7 @@ package dev.ftb.packcompanion.features;
 
 public abstract class CommonFeature {
     public void setup() {
-        if (!isEnabled()) {
+        if (isDisabled()) {
             return;
         }
 
@@ -11,7 +11,7 @@ public abstract class CommonFeature {
 
     public abstract void initialize();
 
-    public boolean isEnabled() {
-        return false;
+    public boolean isDisabled() {
+        return true;
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/features/CommonFeature.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/CommonFeature.java
@@ -1,0 +1,17 @@
+package dev.ftb.packcompanion.features;
+
+public abstract class CommonFeature {
+    public void setup() {
+        if (!isEnabled()) {
+            return;
+        }
+
+        initialize();
+    }
+
+    public abstract void initialize();
+
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/features/Features.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/Features.java
@@ -1,0 +1,29 @@
+package dev.ftb.packcompanion.features;
+
+import dev.ftb.packcompanion.features.buffs.MobEntityBuff;
+import dev.ftb.packcompanion.features.spawners.SpawnerManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Features {
+    public static final Features INSTANCE = new Features();
+
+    List<CommonFeature> commonFeatures = new ArrayList<>();
+    List<ServerFeature> serverFeatures = new ArrayList<>();
+
+    private Features() {
+        this.serverFeatures.addAll(List.of(
+            new MobEntityBuff(),
+            new SpawnerManager()
+        ));
+    }
+
+    public List<CommonFeature> getCommonFeatures() {
+        return commonFeatures;
+    }
+
+    public List<ServerFeature> getServerFeatures() {
+        return serverFeatures;
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
@@ -2,12 +2,12 @@ package dev.ftb.packcompanion.features;
 
 import net.minecraft.server.MinecraftServer;
 
-public abstract class ServerFeature {
+public abstract class ServerFeature extends CommonFeature {
     private boolean initialized = false;
     private MinecraftServer server;
 
     public void setup(MinecraftServer server) {
-        if (!isEnabled()) {
+        if (isDisabled()) {
             return;
         }
 
@@ -19,13 +19,7 @@ public abstract class ServerFeature {
         }
     }
 
-    public abstract void initialize();
-
     public MinecraftServer getServer() {
         return server;
-    }
-
-    public boolean isEnabled() {
-        return false;
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
@@ -16,7 +16,6 @@ public abstract class ServerFeature {
         if (!initialized) {
             initialized = true;
             initialize();
-            System.out.println("Initialized " + this.getClass().getSimpleName());
         }
     }
 

--- a/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/ServerFeature.java
@@ -1,0 +1,32 @@
+package dev.ftb.packcompanion.features;
+
+import net.minecraft.server.MinecraftServer;
+
+public abstract class ServerFeature {
+    private boolean initialized = false;
+    private MinecraftServer server;
+
+    public void setup(MinecraftServer server) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        this.server = server;
+
+        if (!initialized) {
+            initialized = true;
+            initialize();
+            System.out.println("Initialized " + this.getClass().getSimpleName());
+        }
+    }
+
+    public abstract void initialize();
+
+    public MinecraftServer getServer() {
+        return server;
+    }
+
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/features/buffs/MobEntityBuff.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/buffs/MobEntityBuff.java
@@ -1,0 +1,34 @@
+package dev.ftb.packcompanion.features.buffs;
+
+import dev.architectury.event.EventResult;
+import dev.architectury.event.events.common.EntityEvent;
+import dev.ftb.packcompanion.config.PCServerConfig;
+import dev.ftb.packcompanion.features.ServerFeature;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.monster.Enemy;
+import net.minecraft.world.entity.monster.Zombie;
+
+public class MobEntityBuff extends ServerFeature {
+    @Override
+    public void initialize() {
+        // On entity load
+        EntityEvent.ADD.register((entity, world) -> {
+            if (entity instanceof Enemy && entity instanceof Mob mob) {
+                AttributeInstance attribute = mob.getAttribute(Attributes.MAX_HEALTH);
+                if (attribute != null) {
+                    attribute.setBaseValue(attribute.getBaseValue() * PCServerConfig.MODIFY_MOB_BASE_HEALTH.get());
+                    ((Mob) entity).setHealth((float) attribute.getBaseValue());
+                }
+            }
+
+            return EventResult.pass();
+        });
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return PCServerConfig.MODIFY_MOB_BASE_HEALTH.get() > 0;
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/features/buffs/MobEntityBuff.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/buffs/MobEntityBuff.java
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.monster.Enemy;
-import net.minecraft.world.entity.monster.Zombie;
 
 public class MobEntityBuff extends ServerFeature {
     @Override
@@ -19,7 +18,7 @@ public class MobEntityBuff extends ServerFeature {
                 AttributeInstance attribute = mob.getAttribute(Attributes.MAX_HEALTH);
                 if (attribute != null) {
                     attribute.setBaseValue(attribute.getBaseValue() * PCServerConfig.MODIFY_MOB_BASE_HEALTH.get());
-                    ((Mob) entity).setHealth((float) attribute.getBaseValue());
+                    mob.setHealth((float) attribute.getBaseValue());
                 }
             }
 
@@ -28,7 +27,7 @@ public class MobEntityBuff extends ServerFeature {
     }
 
     @Override
-    public boolean isEnabled() {
-        return PCServerConfig.MODIFY_MOB_BASE_HEALTH.get() > 0;
+    public boolean isDisabled() {
+        return PCServerConfig.MODIFY_MOB_BASE_HEALTH.get() == 0.0D;
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
@@ -1,5 +1,6 @@
 package dev.ftb.packcompanion.features.spawners;
 
+import com.google.common.base.Suppliers;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -44,7 +45,7 @@ public class SpawnerManager extends ServerFeature {
     private DataStore dataStore;
 
     // Defer loading so the config and registry are initialized
-    private final LazyValue<List<EntityType<?>>> randomEntities = new LazyValue<>(() -> {
+    private final Supplier<List<EntityType<?>>> randomEntities = Suppliers.memoize(() -> {
         List<String> randomEntities = PCServerConfig.SPAWNERS_USE_RANDOM_ENTITY.get();
         List<EntityType<?>> entities = new ArrayList<>();
         for (String entity : randomEntities) {
@@ -92,8 +93,8 @@ public class SpawnerManager extends ServerFeature {
     public SpawnerManager() {}
 
     @Override
-    public boolean isEnabled() {
-        return PCServerConfig.SPAWNERS_ALLOW_RESPAWN.get();
+    public boolean isDisabled() {
+        return !PCServerConfig.SPAWNERS_ALLOW_RESPAWN.get();
     }
 
     private void onServerTick(ServerLevel serverLevel) {
@@ -220,30 +221,6 @@ public class SpawnerManager extends ServerFeature {
 
         public List<MobSpawnerData> getBrokenSpawners() {
             return brokenSpawners;
-        }
-    }
-
-    /**
-     * A lazy value that is only computed once
-     */
-    public static class LazyValue<T> implements Supplier<T> {
-        private volatile T value;
-        private final Supplier<T> supplier;
-
-        public LazyValue(Supplier<T> supplier) {
-            this.supplier = supplier;
-        }
-
-        @Override
-        public T get() {
-            if (value == null) {
-                synchronized (this) {
-                    if (value == null) {
-                        value = supplier.get();
-                    }
-                }
-            }
-            return value;
         }
     }
 }

--- a/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
@@ -41,6 +41,7 @@ public class SpawnerManager {
 
     private boolean initialized = false;
     private static final SpawnerManager INSTANCE = new SpawnerManager();
+    private DataStore dataStore;
 
     // Defer loading so the config and registry are initialized
     private final LazyValue<List<EntityType<?>>> randomEntities = new LazyValue<>(() -> {
@@ -67,6 +68,7 @@ public class SpawnerManager {
         }
 
         initialized = true;
+        dataStore = DataStore.create(server);
 
         BlockEvent.BREAK.register((level, pos, state, player, xp) -> {
             if (level == null || level.getServer() == null || level.isClientSide) {
@@ -84,7 +86,7 @@ public class SpawnerManager {
 
             // Spawn data
             var compound = spawnerBlockEntity.saveWithoutMetadata();
-            DataStore dataStore = DataStore.create(level.getServer());
+            DataStore dataStore = this.getDataStore();
             dataStore.brokenSpawners.add(new MobSpawnerData(pos, compound, level.dimension()));
             dataStore.setDirty();
 
@@ -100,7 +102,7 @@ public class SpawnerManager {
             return;
         }
 
-        DataStore dataStore = DataStore.create(serverLevel.getServer());
+        DataStore dataStore = this.getDataStore();
         if (dataStore.brokenSpawners.isEmpty()) {
             return;
         }
@@ -166,8 +168,8 @@ public class SpawnerManager {
         return INSTANCE;
     }
 
-    public DataStore getDataStore(MinecraftServer server) {
-        return DataStore.create(server);
+    public DataStore getDataStore() {
+        return dataStore;
     }
 
     public record MobSpawnerData(

--- a/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
+++ b/common/src/main/java/dev/ftb/packcompanion/features/spawners/SpawnerManager.java
@@ -1,0 +1,246 @@
+package dev.ftb.packcompanion.features.spawners;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.architectury.event.EventResult;
+import dev.architectury.event.events.common.BlockEvent;
+import dev.architectury.event.events.common.TickEvent;
+import dev.ftb.packcompanion.config.PCServerConfig;
+import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.saveddata.SavedData;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class SpawnerManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpawnerManager.class);
+
+    private boolean initialized = false;
+    private static final SpawnerManager INSTANCE = new SpawnerManager();
+
+    // Defer loading so the config and registry are initialized
+    private final LazyValue<List<EntityType<?>>> randomEntities = new LazyValue<>(() -> {
+        List<String> randomEntities = PCServerConfig.SPAWNERS_USE_RANDOM_ENTITY.get();
+        List<EntityType<?>> entities = new ArrayList<>();
+        for (String entity : randomEntities) {
+            EntityType<?> entityType = Registry.ENTITY_TYPE.get(new ResourceLocation(entity));
+            if (entityType == EntityType.PIG && !entity.endsWith("pig")) {
+                continue; // Failed as the registry default is pig
+            }
+
+            entities.add(entityType);
+        }
+        return entities;
+    });
+
+    private SpawnerManager() {
+
+    }
+
+    public void init(MinecraftServer server) {
+        if (initialized) {
+            return;
+        }
+
+        initialized = true;
+
+        BlockEvent.BREAK.register((level, pos, state, player, xp) -> {
+            if (level == null || level.getServer() == null || level.isClientSide) {
+                return EventResult.pass();
+            }
+
+            if (state.getBlock() != Blocks.SPAWNER) {
+                return EventResult.pass();
+            }
+
+            BlockEntity blockEntity = level.getBlockEntity(pos);
+            if (!(blockEntity instanceof SpawnerBlockEntity spawnerBlockEntity)) {
+                return EventResult.pass();
+            }
+
+            // Spawn data
+            var compound = spawnerBlockEntity.saveWithoutMetadata();
+            DataStore dataStore = DataStore.create(level.getServer());
+            dataStore.brokenSpawners.add(new MobSpawnerData(pos, compound, level.dimension()));
+            dataStore.setDirty();
+
+            return EventResult.pass();
+        });
+
+        TickEvent.ServerLevelTick.SERVER_LEVEL_POST.register(this::onServerTick);
+    }
+
+    private void onServerTick(ServerLevel serverLevel) {
+        // Only run this method every 10 seconds
+        if (serverLevel.getGameTime() % 200 != 0) {
+            return;
+        }
+
+        DataStore dataStore = DataStore.create(serverLevel.getServer());
+        if (dataStore.brokenSpawners.isEmpty()) {
+            return;
+        }
+
+        List<MobSpawnerData> dimensionSpawners = dataStore.brokenSpawners.stream()
+                .filter(e -> e.dimension().equals(serverLevel.dimension()))
+                .toList();
+
+        if (dimensionSpawners.isEmpty()) {
+            return;
+        }
+
+        Instant currentTime = Instant.now();
+        int respawnInterval = PCServerConfig.SPAWNERS_RESPAWN_INTERVAL.get();
+
+        // Copy list to avoid concurrent modification
+        for (MobSpawnerData spawnerData : dimensionSpawners) {
+            if (currentTime.isBefore(spawnerData.breakTime.plus(respawnInterval, ChronoUnit.MINUTES))) {
+                continue;
+            }
+
+            BlockState state = serverLevel.getBlockState(spawnerData.pos);
+            if (!state.isAir() || !state.getMaterial().isReplaceable()) {
+                // Can't respawn spawner
+                dataStore.brokenSpawners.remove(spawnerData);
+                dataStore.setDirty();
+                continue;
+            }
+
+            // Respawn spawner
+            serverLevel.setBlock(spawnerData.pos, Blocks.SPAWNER.defaultBlockState(), Block.UPDATE_ALL);
+            BlockEntity blockEntity = serverLevel.getBlockEntity(spawnerData.pos);
+            if (!(blockEntity instanceof SpawnerBlockEntity spawnerBlockEntity)) {
+                continue;
+            }
+
+            // Set spawn data
+            CompoundTag compound = spawnerData.spawnerData;
+            List<EntityType<?>> randomEntities = this.randomEntities.get();
+            // Only happens if the random entity list is not empty
+            if (!randomEntities.isEmpty()) {
+                EntityType<?> foundEntity;
+                if (randomEntities.size() == 1) {
+                    foundEntity = randomEntities.get(0);
+                } else {
+                    foundEntity = randomEntities.get(serverLevel.random.nextInt(randomEntities.size()));
+                }
+
+                var entityCompound = Util.make(new CompoundTag(), tag -> tag.put("entity",
+                        Util.make(new CompoundTag(), entityTag -> entityTag.putString("id", Objects.requireNonNull(foundEntity.arch$registryName()).toString()))));
+
+                compound.put("SpawnData", entityCompound);
+            }
+
+            spawnerBlockEntity.load(compound);
+            spawnerBlockEntity.setChanged();
+            dataStore.brokenSpawners.remove(spawnerData);
+            dataStore.setDirty();
+        }
+    }
+
+    public static SpawnerManager get() {
+        return INSTANCE;
+    }
+
+    public DataStore getDataStore(MinecraftServer server) {
+        return DataStore.create(server);
+    }
+
+    public record MobSpawnerData(
+       BlockPos pos,
+       CompoundTag spawnerData,
+       Instant breakTime,
+       ResourceKey<Level> dimension
+    ) {
+        private static final Codec<ResourceKey<Level>> DIMENSION_CODEC = ResourceKey.codec(Registry.DIMENSION_REGISTRY);
+        private static final Codec<Instant> INSTANT_CODEC = Codec.LONG.xmap(Instant::ofEpochMilli, Instant::toEpochMilli);
+        public static final Codec<MobSpawnerData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                BlockPos.CODEC.fieldOf("pos").forGetter(MobSpawnerData::pos),
+                CompoundTag.CODEC.fieldOf("spawner_data").forGetter(MobSpawnerData::spawnerData),
+                INSTANT_CODEC.fieldOf("break_time").forGetter(MobSpawnerData::breakTime),
+                DIMENSION_CODEC.fieldOf("dimension").forGetter(MobSpawnerData::dimension)
+        ).apply(instance, MobSpawnerData::new));
+
+        public MobSpawnerData(BlockPos pos, CompoundTag spawnerData, ResourceKey<Level> dimension) {
+            this(pos, spawnerData, Instant.now(), dimension);
+        }
+    }
+
+    public static class DataStore extends SavedData {
+        private final List<MobSpawnerData> brokenSpawners = new ArrayList<>();
+
+        private DataStore() {}
+
+        private DataStore(CompoundTag tag) {
+            if (!tag.contains("broken_spawners")) {
+                return;
+            }
+
+            brokenSpawners.addAll(MobSpawnerData.CODEC.listOf().parse(new Dynamic<>(NbtOps.INSTANCE, tag.getCompound("broken_spawners"))).result().orElse(new ArrayList<>()));
+        }
+
+        public static DataStore create(MinecraftServer server) {
+            return server.getLevel(Level.OVERWORLD).getDataStorage()
+                    .computeIfAbsent(DataStore::new, DataStore::new, "ftbpc-spawner-manager");
+        }
+
+        @Override
+        @NotNull
+        public CompoundTag save(CompoundTag compoundTag) {
+            compoundTag.put("broken_spawners", MobSpawnerData.CODEC.listOf().encodeStart(NbtOps.INSTANCE, brokenSpawners).result().orElse(new CompoundTag()));
+            return compoundTag;
+        }
+
+        public List<MobSpawnerData> getBrokenSpawners() {
+            return brokenSpawners;
+        }
+    }
+
+    /**
+     * A lazy value that is only computed once
+     */
+    public static class LazyValue<T> implements Supplier<T> {
+        private volatile T value;
+        private final Supplier<T> supplier;
+
+        public LazyValue(Supplier<T> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public T get() {
+            if (value == null) {
+                synchronized (this) {
+                    if (value == null) {
+                        value = supplier.get();
+                    }
+                }
+            }
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to configure a feature I'm calling `respawnable spawners`

When abled, at a specific interval, the game will watch for all broken spawners and respawn them after a configured interval. This will by default return the original spawners, but can be configured to use a list of entities to spawn from. All invalid entities are removed at load time, if there is no valid entities left, we default back to the original spawner. 

Let me know if FTB Lib can replace any of the systems I hacked into the bottom :D