### PR TITLE
[1.21.1] Add Performance mixins to improve reload

### DIFF
--- a/common/src/main/java/dev/ftb/packcompanion/config/PCClientConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCClientConfig.java
@@ -42,8 +42,8 @@ public interface PCClientConfig {
 
     SNBTConfig PERFORMANCE = CONFIG.addGroup("performance");
 
-    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("reload_performance", true)
-            .comment("Enable reloading performance by disabling rebuilding block cache");
+    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("skip_block_cache_rebuild", true)
+            .comment("Improve reloading performance by disabling block cache rebuild on server resource reload");
 
     static void load() {
         ConfigUtil.loadDefaulted(CONFIG, PackCompanionExpectPlatform.getConfigDirectory(), PackCompanionAPI.MOD_ID);

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCClientConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCClientConfig.java
@@ -39,6 +39,12 @@ public interface PCClientConfig {
     StringValue SUPPORT_DISCORD_URL = PAUSE_SCREEN.addString("support_discord_url", "https://go.ftb.team/discord")
             .comment("The URL to open when the support provider's Discord icon is clicked. If this is empty, the Discord icon will not be shown.");
 
+
+    SNBTConfig PERFORMANCE = CONFIG.addGroup("performance");
+
+    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("reload_performance", true)
+            .comment("Enable reloading performance by disabling rebuilding block cache");
+
     static void load() {
         ConfigUtil.loadDefaulted(CONFIG, PackCompanionExpectPlatform.getConfigDirectory(), PackCompanionAPI.MOD_ID);
     }

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -26,8 +26,8 @@ public interface PCServerConfig {
 
     SNBTConfig PERFORMANCE = CONFIG.addGroup("performance");
 
-    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("reload_performance", true)
-            .comment("Enable reloading performance by disabling rebuilding block cache");
+    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("skip_block_cache_rebuild", true)
+            .comment("Improve reloading performance by disabling block cache rebuild on client tag data reload");
 
     static void load(MinecraftServer server) {
         ConfigUtil.loadDefaulted(CONFIG, server.getWorldPath(ConfigUtil.SERVER_CONFIG_DIR), PackCompanionAPI.MOD_ID);

--- a/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/common/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -24,6 +24,11 @@ public interface PCServerConfig {
     DoubleValue MODIFY_MOB_BASE_HEALTH = CONFIG.addDouble("modify_mob_base_health", 0D, 0D, 1000D)
             .comment("If non-zero, set the base health of all mobs to be multiplied by this value. Set to 0 to disable.");
 
+    SNBTConfig PERFORMANCE = CONFIG.addGroup("performance");
+
+    BooleanValue RELOAD_PERFORMANCE = PERFORMANCE.addBoolean("reload_performance", true)
+            .comment("Enable reloading performance by disabling rebuilding block cache");
+
     static void load(MinecraftServer server) {
         ConfigUtil.loadDefaulted(CONFIG, server.getWorldPath(ConfigUtil.SERVER_CONFIG_DIR), PackCompanionAPI.MOD_ID);
     }

--- a/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/ReloadableServerResourcesMixin.java
+++ b/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/ReloadableServerResourcesMixin.java
@@ -4,7 +4,6 @@ import dev.ftb.packcompanion.config.PCServerConfig;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.ApiStatus;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;

--- a/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/ReloadableServerResourcesMixin.java
+++ b/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/ReloadableServerResourcesMixin.java
@@ -1,0 +1,23 @@
+package dev.ftb.packcompanion.mixin.features.performance;
+
+import dev.ftb.packcompanion.config.PCServerConfig;
+import net.minecraft.server.ReloadableServerResources;
+import net.minecraft.world.level.block.Blocks;
+import org.jetbrains.annotations.ApiStatus;
+import org.spongepowered.asm.mixin.Debug;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Deprecated(forRemoval = true)
+@ApiStatus.ScheduledForRemoval(inVersion = "1.21.3")
+@Mixin(ReloadableServerResources.class)
+public class ReloadableServerResourcesMixin {
+
+    @Redirect(method = "updateRegistryTags()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/Blocks;rebuildCache()V"))
+    private void rebuildBlockCache() {
+        if (!PCServerConfig.RELOAD_PERFORMANCE.get()) {
+            Blocks.rebuildCache();
+        }
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/TagCollectorMixin.java
+++ b/common/src/main/java/dev/ftb/packcompanion/mixin/features/performance/TagCollectorMixin.java
@@ -1,0 +1,22 @@
+package dev.ftb.packcompanion.mixin.features.performance;
+
+import dev.ftb.packcompanion.config.PCClientConfig;
+import net.minecraft.client.multiplayer.TagCollector;
+import org.jetbrains.annotations.ApiStatus;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Deprecated(forRemoval = true)
+@ApiStatus.ScheduledForRemoval(inVersion = "1.21.3")
+@Mixin(TagCollector.class)
+public class TagCollectorMixin {
+
+    @Inject(method = "refreshBuiltInTagDependentData", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/Blocks;rebuildCache()V"), cancellable = true)
+    private static void rebuildBlockCache(CallbackInfo ci) {
+        if (PCClientConfig.RELOAD_PERFORMANCE.get()) {
+            ci.cancel();
+        }
+    }
+}

--- a/common/src/main/java/dev/ftb/packcompanion/mixin/features/sparsestructures/RegistryDataLoaderMixin.java
+++ b/common/src/main/java/dev/ftb/packcompanion/mixin/features/sparsestructures/RegistryDataLoaderMixin.java
@@ -16,7 +16,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Debug(export = true)
 @Mixin(RegistryDataLoader.class)
 public abstract class RegistryDataLoaderMixin {
     @Inject(

--- a/common/src/main/resources/ftbpc-common.mixins.json
+++ b/common/src/main/resources/ftbpc-common.mixins.json
@@ -6,12 +6,14 @@
   "client": [
     "features.notoast.AdvancementToastMixin",
     "features.notoast.TutorialMixin",
-    "features.singleplayerseed.WorldGenSettingsComponentMixin"
+    "features.singleplayerseed.WorldGenSettingsComponentMixin",
+    "features.performance.TagCollectorMixin"
   ],
   "mixins": [
     "features.sparsestructures.RegistryDataLoaderMixin",
     "features.spawners.SpawnDataMixin",
-    "features.spawners.SpawnerMixin"
+    "features.spawners.SpawnerMixin",
+    "features.performance.ReloadableServerResourcesMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This backports changes from Minecraft 1.21.3 that improves the performance of the reload command by no rebuilding the Block cache

This has been tested by the pack dev and been shown to not break anything and improve reloading times



This is inspired by these two Mixins
https://github.com/LoveTropics/LTExtras/blob/lt24/src/main/java/com/lovetropics/extras/mixin/perf/ReloadableServerResourcesMixin.java
https://github.com/LoveTropics/LTExtras/blob/lt24/src/main/java/com/lovetropics/extras/mixin/client/perf/TagCollectorMixin.java