### PR TITLE
feat: Implement schematic perimeter sealing and cleanup phases

### DIFF
--- a/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -6,6 +6,7 @@ import dev.ftb.mods.ftblibrary.snbt.config.DoubleValue;
 import dev.ftb.mods.ftblibrary.snbt.config.IntValue;
 import dev.ftb.mods.ftblibrary.snbt.config.SNBTConfig;
 import dev.ftb.mods.ftblibrary.snbt.config.StringListValue;
+import dev.ftb.mods.ftblibrary.snbt.config.StringValue;
 import dev.ftb.packcompanion.api.PackCompanionAPI;
 import dev.ftb.packcompanion.config.values.AbstractMapValue;
 import net.minecraft.server.MinecraftServer;
@@ -45,8 +46,13 @@ public interface PCServerConfig {
 
     BooleanValue SCHEMATIC_SEAL_PERIMETER = SCHEMATICS.addBoolean("seal_perimeter", true)
             .comment("If true, before pasting begins the worker wraps the schematic bounding box in a 1-block-thick",
-                    "shell of bedrock. This prevents water/lava/falling-blocks from neighbouring terrain flowing into",
-                    "the in-progress paste while it runs (chunk-by-chunk pastes can take many minutes).");
+                    "shell of the configured shell_block. This prevents water/lava/falling-blocks from neighbouring",
+                    "terrain flowing into the in-progress paste while it runs (chunk-by-chunk pastes can take many minutes).");
+
+    StringValue SCHEMATIC_SHELL_BLOCK = SCHEMATICS.addString("shell_block", "minecraft:barrier")
+            .comment("Block ID used for the perimeter shell when seal_perimeter is enabled. Defaults to barrier so the",
+                    "shell is invisible in-game; bedrock is another common choice if you want it visible/indestructible.",
+                    "Must be a valid block resource location; falls back to barrier if the block can't be resolved.");
 
     BooleanValue SCHEMATIC_CLEANUP_FLUIDS = SCHEMATICS.addBoolean("cleanup_fluids", true)
             .comment("If true, after paste finishes the worker scans the schematic bounding box and replaces any",
@@ -58,9 +64,9 @@ public interface PCServerConfig {
                     "above the bounding box. Disabled by default since some schematics use falling blocks deliberately.");
 
     BooleanValue SCHEMATIC_REMOVE_SHELL_AFTER_PASTE = SCHEMATICS.addBoolean("remove_shell_after_paste", true)
-            .comment("If true, the bedrock shell from seal_perimeter is removed during cleanup (replaced with air).",
+            .comment("If true, the shell from seal_perimeter is removed during cleanup (replaced with air).",
                     "If false, the shell remains permanently — fully bulletproof against later fluid intrusion but",
-                    "visible as a bedrock cage around the structure.");
+                    "visible/tangible depending on the chosen shell_block.");
 
     IntValue SCHEMATIC_CLEANUP_SCAN_MULTIPLIER = SCHEMATICS.addInt("cleanup_scan_multiplier", 20, 1, 1000)
             .comment("Cleanup scans many cells per tick but writes few (most cells are schematic-solid and skip).",

--- a/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
+++ b/src/main/java/dev/ftb/packcompanion/config/PCServerConfig.java
@@ -43,6 +43,30 @@ public interface PCServerConfig {
             .comment("Maximum number of blocks/tick that can be pasted, divided equally among all current paste workers",
                     "A value of 0 indicates no limit");
 
+    BooleanValue SCHEMATIC_SEAL_PERIMETER = SCHEMATICS.addBoolean("seal_perimeter", true)
+            .comment("If true, before pasting begins the worker wraps the schematic bounding box in a 1-block-thick",
+                    "shell of bedrock. This prevents water/lava/falling-blocks from neighbouring terrain flowing into",
+                    "the in-progress paste while it runs (chunk-by-chunk pastes can take many minutes).");
+
+    BooleanValue SCHEMATIC_CLEANUP_FLUIDS = SCHEMATICS.addBoolean("cleanup_fluids", true)
+            .comment("If true, after paste finishes the worker scans the schematic bounding box and replaces any",
+                    "water/lava found at positions where the schematic itself contained air. This mops up fluid that",
+                    "leaked in during paste. Has no effect on cells where the schematic intentionally placed fluid.");
+
+    BooleanValue SCHEMATIC_CLEANUP_FALLING_BLOCKS = SCHEMATICS.addBoolean("cleanup_falling_blocks", false)
+            .comment("If true, the post-paste cleanup also removes sand/gravel/concrete-powder etc. that fell in from",
+                    "above the bounding box. Disabled by default since some schematics use falling blocks deliberately.");
+
+    BooleanValue SCHEMATIC_REMOVE_SHELL_AFTER_PASTE = SCHEMATICS.addBoolean("remove_shell_after_paste", true)
+            .comment("If true, the bedrock shell from seal_perimeter is removed during cleanup (replaced with air).",
+                    "If false, the shell remains permanently — fully bulletproof against later fluid intrusion but",
+                    "visible as a bedrock cage around the structure.");
+
+    IntValue SCHEMATIC_CLEANUP_SCAN_MULTIPLIER = SCHEMATICS.addInt("cleanup_scan_multiplier", 20, 1, 1000)
+            .comment("Cleanup scans many cells per tick but writes few (most cells are schematic-solid and skip).",
+                    "This multiplier sets how many cells are scanned per paste-budget unit. 20 means a 200 blocks/tick",
+                    "paste rate scans 4000 cells/tick during cleanup. Raise for faster cleanup, lower for less tick load.");
+
     AbstractMapValue.CodecBased<GameType> DIMENSION_FORCED_GAMEMODES = CONFIG.add(new AbstractMapValue.CodecBased<>(
             CONFIG,
             "dimension_forced_gamemodes",

--- a/src/main/java/dev/ftb/packcompanion/features/schematic/SchematicPasteWorker.java
+++ b/src/main/java/dev/ftb/packcompanion/features/schematic/SchematicPasteWorker.java
@@ -1,6 +1,7 @@
 package dev.ftb.packcompanion.features.schematic;
 
 import com.mojang.datafixers.util.Either;
+import dev.ftb.packcompanion.config.PCServerConfig;
 import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
@@ -19,6 +20,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -30,9 +32,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 public class SchematicPasteWorker {
     private static final BlockState AIR_STATE = Blocks.AIR.defaultBlockState();
+    private static final BlockState SHELL_STATE = Blocks.BEDROCK.defaultBlockState();
+
     private final ResourceLocation location;
     private final BlockPos basePos;
     private final int speed;
@@ -52,6 +57,16 @@ public class SchematicPasteWorker {
     private int totalChunks;
     private int chunkMinSX, chunkMaxSX, chunkMinSZ, chunkMaxSZ;
     private final Set<ChunkPos> forcedChunks = new HashSet<>();
+
+    private int phaseMinX, phaseMaxX, phaseMinY, phaseMaxY, phaseMinZ, phaseMaxZ;
+    private int phaseCurX, phaseCurY, phaseCurZ;
+    private boolean phaseChunkActive;
+
+    private boolean sealEnabled;
+    private boolean cleanupFluidsEnabled;
+    private boolean cleanupFallingEnabled;
+    private boolean removeShell;
+    private int cleanupScanMultiplier;
 
     public SchematicPasteWorker(@Nullable CommandSourceStack sourceStack, ResourceLocation location, Either<ServerLevel,ResourceLocation> levelOrDimensionId, BlockPos basePos, int speed, boolean perTick) {
         this.sourceStack = sourceStack;
@@ -79,10 +94,22 @@ public class SchematicPasteWorker {
                     c.getInt("speed"),
                     c.getBoolean("perTick"));
             worker.completedChunks = c.getInt("completedChunks");
+            String resumePhase = c.contains("resumePhase") ? c.getString("resumePhase") : "PASTING";
+            worker.state = State.INIT;
+            worker.resumePhaseHint = resumePhase;
+            worker.sealEnabled = c.getBoolean("sealEnabled");
+            worker.cleanupFluidsEnabled = c.getBoolean("cleanupFluidsEnabled");
+            worker.cleanupFallingEnabled = c.getBoolean("cleanupFallingEnabled");
+            worker.removeShell = c.getBoolean("removeShell");
+            worker.cleanupScanMultiplier = c.contains("cleanupScanMultiplier") ? c.getInt("cleanupScanMultiplier") : 20;
+            worker.configSnapshotLoaded = true;
             return Optional.of(worker);
         }
         return Optional.empty();
     }
+
+    private String resumePhaseHint = null;
+    private boolean configSnapshotLoaded = false;
 
     public Tag saveNBT() {
         return Util.make(new CompoundTag(), tag -> {
@@ -92,77 +119,133 @@ public class SchematicPasteWorker {
             tag.putInt("speed", speed);
             tag.putInt("completedChunks", completedChunks);
             if (perTick) tag.putBoolean("perTick", true);
+            tag.putString("resumePhase", currentPhaseTag());
+            tag.putBoolean("sealEnabled", sealEnabled);
+            tag.putBoolean("cleanupFluidsEnabled", cleanupFluidsEnabled);
+            tag.putBoolean("cleanupFallingEnabled", cleanupFallingEnabled);
+            tag.putBoolean("removeShell", removeShell);
+            tag.putInt("cleanupScanMultiplier", cleanupScanMultiplier);
         });
     }
 
+    private String currentPhaseTag() {
+        return switch (state) {
+            case SEAL_PRELOAD, SEALING -> "SEALING";
+            case CLEAN_PRELOAD, CLEANING -> "CLEANING";
+            default -> "PASTING";
+        };
+    }
+
     public void tick(MinecraftServer server, int globalLimit) {
-        if (state == State.INIT) {
-            if (level == null) {
-                level = server.getLevel(ResourceKey.create(Registries.DIMENSION, dimensionId));
+        switch (state) {
+            case INIT -> {
                 if (level == null) {
-                    SchematicPasteManager.LOGGER.error("unknown level {}", dimensionId);
-                    fail("Invalid level %s", dimensionId);
-                    return;
-                }
-            }
-            state = State.LOADING;
-            loadSchematicDataAsync(server);
-        } else if (state == State.PRELOAD) {
-            if (chunkQueue == null) {
-                chunkQueue = new ArrayDeque<>();
-                int minCX = basePos.getX() >> 4;
-                int maxCX = (basePos.getX() + data.getWidth() - 1) >> 4;
-                int minCZ = basePos.getZ() >> 4;
-                int maxCZ = (basePos.getZ() + data.getLength() - 1) >> 4;
-                for (int cx = minCX; cx <= maxCX; cx++) {
-                    for (int cz = minCZ; cz <= maxCZ; cz++) {
-                        chunkQueue.addLast(new ChunkPos(cx, cz));
+                    level = server.getLevel(ResourceKey.create(Registries.DIMENSION, dimensionId));
+                    if (level == null) {
+                        SchematicPasteManager.LOGGER.error("unknown level {}", dimensionId);
+                        fail("Invalid level %s", dimensionId);
+                        return;
                     }
                 }
-                totalChunks = chunkQueue.size();
-                for (int i = 0; i < completedChunks && !chunkQueue.isEmpty(); i++) {
-                    chunkQueue.pollFirst();
+                if (!configSnapshotLoaded) {
+                    sealEnabled = PCServerConfig.SCHEMATIC_SEAL_PERIMETER.get();
+                    cleanupFluidsEnabled = PCServerConfig.SCHEMATIC_CLEANUP_FLUIDS.get();
+                    cleanupFallingEnabled = PCServerConfig.SCHEMATIC_CLEANUP_FALLING_BLOCKS.get();
+                    removeShell = PCServerConfig.SCHEMATIC_REMOVE_SHELL_AFTER_PASTE.get();
+                    cleanupScanMultiplier = PCServerConfig.SCHEMATIC_CLEANUP_SCAN_MULTIPLIER.get();
                 }
-                SchematicPasteManager.LOGGER.info("schematic covers {} chunks, {} remaining", totalChunks, chunkQueue.size());
+                state = State.LOADING;
+                loadSchematicDataAsync(server);
             }
-            if (chunkQueue.isEmpty()) {
-                state = State.FINISHED;
-                return;
+            case SEAL_PRELOAD -> tickPreload(State.SEALING, this::buildShellChunkQueue, this::beginShellChunk);
+            case SEALING -> tickShell(globalLimit);
+            case PRELOAD -> tickPreload(State.PASTING, this::buildPasteChunkQueue, this::beginPastingChunk);
+            case PASTING -> tickPaste(globalLimit);
+            case CLEAN_PRELOAD -> tickPreload(State.CLEANING, this::buildCleanupChunkQueue, this::beginCleanupChunk);
+            case CLEANING -> tickCleanup(globalLimit);
+            default -> {}
+        }
+    }
+
+    private void tickPreload(State workState, Runnable queueBuilder, Consumer<ChunkPos> chunkBeginner) {
+        if (chunkQueue == null) {
+            queueBuilder.run();
+            for (int i = 0; i < completedChunks && !chunkQueue.isEmpty(); i++) {
+                chunkQueue.pollFirst();
             }
-            ChunkPos cp = chunkQueue.peek();
-            if (level.hasChunk(cp.x, cp.z)) {
-                beginPastingChunk(cp);
-                state = State.PASTING;
-            } else if (forcedChunks.add(cp)) {
-                level.setChunkForced(cp.x, cp.z, true);
+            SchematicPasteManager.LOGGER.info("schematic {} covers {} chunks ({} remaining)", currentPhaseTag(), totalChunks, chunkQueue.size());
+        }
+        if (chunkQueue.isEmpty()) {
+            advancePhase();
+            return;
+        }
+        ChunkPos cp = chunkQueue.peek();
+        if (level.hasChunk(cp.x, cp.z)) {
+            chunkBeginner.accept(cp);
+            phaseChunkActive = true;
+            state = workState;
+        } else if (forcedChunks.add(cp)) {
+            level.setChunkForced(cp.x, cp.z, true);
+        }
+    }
+
+    private void advancePhase() {
+        chunkQueue = null;
+        completedChunks = 0;
+        totalChunks = 0;
+        phaseChunkActive = false;
+        switch (state) {
+            case SEAL_PRELOAD, SEALING -> state = State.PRELOAD;
+            case PRELOAD, PASTING -> state = cleanupEnabled() ? State.CLEAN_PRELOAD : State.FINISHED;
+            case CLEAN_PRELOAD, CLEANING -> state = State.FINISHED;
+            default -> state = State.FINISHED;
+        }
+    }
+
+    private boolean cleanupEnabled() {
+        return cleanupFluidsEnabled || cleanupFallingEnabled || (sealEnabled && removeShell);
+    }
+
+    private void buildPasteChunkQueue() {
+        chunkQueue = new ArrayDeque<>();
+        int minCX = basePos.getX() >> 4;
+        int maxCX = (basePos.getX() + data.getWidth() - 1) >> 4;
+        int minCZ = basePos.getZ() >> 4;
+        int maxCZ = (basePos.getZ() + data.getLength() - 1) >> 4;
+        for (int cx = minCX; cx <= maxCX; cx++) {
+            for (int cz = minCZ; cz <= maxCZ; cz++) {
+                chunkQueue.addLast(new ChunkPos(cx, cz));
             }
-        } else if (state == State.PASTING) {
-            int pasted = 0;
-            while (pasted < blocksPerTick && pasted < globalLimit) {
-                BlockPos destPos = basePos.offset(currentPos);
-                if (level.setBlock(destPos, data.getBlockAt(currentPos, AIR_STATE), Block.UPDATE_CLIENTS)) {
-                    data.getBlockEntityDataAt(currentPos).ifPresent(beData -> {
-                        try {
-                            BlockEntity be = level.getBlockEntity(destPos);
-                            if (be != null) {
-                                be.load(beData);
-                            }
-                        } catch (Exception e) {
-                            SchematicPasteFeature.LOGGER.error("caught exception while loading block entity data at {}: {} / {}",
-                                    destPos, e.getClass().getName(), e.getMessage());
+        }
+        totalChunks = chunkQueue.size();
+    }
+
+    private void tickPaste(int globalLimit) {
+        int pasted = 0;
+        while (pasted < blocksPerTick && pasted < globalLimit) {
+            BlockPos destPos = basePos.offset(currentPos);
+            if (level.setBlock(destPos, data.getBlockAt(currentPos, AIR_STATE), Block.UPDATE_CLIENTS)) {
+                data.getBlockEntityDataAt(currentPos).ifPresent(beData -> {
+                    try {
+                        BlockEntity be = level.getBlockEntity(destPos);
+                        if (be != null) {
+                            be.load(beData);
                         }
-                    });
-                    pasted++;
-                }
-                if (!advanceWithinChunk()) {
-                    finishCurrentChunk();
-                    if (chunkQueue.isEmpty()) {
-                        state = State.FINISHED;
-                    } else {
-                        state = State.PRELOAD;
+                    } catch (Exception e) {
+                        SchematicPasteFeature.LOGGER.error("caught exception while loading block entity data at {}: {} / {}",
+                                destPos, e.getClass().getName(), e.getMessage());
                     }
-                    return;
+                });
+                pasted++;
+            }
+            if (!advanceWithinPasteChunk()) {
+                finishCurrentChunk(true);
+                if (chunkQueue.isEmpty()) {
+                    advancePhase();
+                } else {
+                    state = State.PRELOAD;
                 }
+                return;
             }
         }
     }
@@ -175,7 +258,7 @@ public class SchematicPasteWorker {
         currentPos.set(chunkMinSX, 0, chunkMinSZ);
     }
 
-    private boolean advanceWithinChunk() {
+    private boolean advanceWithinPasteChunk() {
         int x = currentPos.getX() + 1;
         if (x > chunkMaxSX) {
             x = chunkMinSX;
@@ -195,15 +278,174 @@ public class SchematicPasteWorker {
         return true;
     }
 
-    private void finishCurrentChunk() {
+    private void finishCurrentChunk(boolean applyBiomes) {
         ChunkPos cp = chunkQueue.pollFirst();
         if (cp != null) {
-            applyBiomesForChunk(cp);
+            if (applyBiomes) {
+                applyBiomesForChunk(cp);
+            }
             if (forcedChunks.remove(cp)) {
                 level.setChunkForced(cp.x, cp.z, false);
             }
         }
         completedChunks++;
+        phaseChunkActive = false;
+    }
+
+    private void buildShellChunkQueue() {
+        chunkQueue = new ArrayDeque<>();
+        int minCX = (basePos.getX() - 1) >> 4;
+        int maxCX = (basePos.getX() + data.getWidth()) >> 4;
+        int minCZ = (basePos.getZ() - 1) >> 4;
+        int maxCZ = (basePos.getZ() + data.getLength()) >> 4;
+        for (int cx = minCX; cx <= maxCX; cx++) {
+            for (int cz = minCZ; cz <= maxCZ; cz++) {
+                chunkQueue.addLast(new ChunkPos(cx, cz));
+            }
+        }
+        totalChunks = chunkQueue.size();
+    }
+
+    private void beginShellChunk(ChunkPos cp) {
+        beginPhaseChunk(cp, basePos.getX() - 1, basePos.getX() + data.getWidth(),
+                basePos.getY() - 1, basePos.getY() + data.getHeight(),
+                basePos.getZ() - 1, basePos.getZ() + data.getLength());
+    }
+
+    private void tickShell(int globalLimit) {
+        int placed = 0;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        while (placed < blocksPerTick && placed < globalLimit) {
+            if (!phaseChunkActive) return;
+            cursor.set(phaseCurX, phaseCurY, phaseCurZ);
+            if (isOnShellLayer(phaseCurX, phaseCurY, phaseCurZ)) {
+                level.setBlock(cursor, SHELL_STATE, Block.UPDATE_CLIENTS);
+                placed++;
+            }
+            if (!advanceWithinPhaseChunk()) {
+                finishCurrentChunk(false);
+                if (chunkQueue.isEmpty()) {
+                    advancePhase();
+                } else {
+                    state = State.SEAL_PRELOAD;
+                }
+                return;
+            }
+        }
+    }
+
+    private boolean isOnShellLayer(int wx, int wy, int wz) {
+        boolean insideX = wx >= basePos.getX() && wx < basePos.getX() + data.getWidth();
+        boolean insideY = wy >= basePos.getY() && wy < basePos.getY() + data.getHeight();
+        boolean insideZ = wz >= basePos.getZ() && wz < basePos.getZ() + data.getLength();
+        return !(insideX && insideY && insideZ);
+    }
+
+    private void buildCleanupChunkQueue() {
+        if (sealEnabled && removeShell) {
+            buildShellChunkQueue();
+        } else {
+            buildPasteChunkQueue();
+        }
+    }
+
+    private void beginCleanupChunk(ChunkPos cp) {
+        if (sealEnabled && removeShell) {
+            beginPhaseChunk(cp, basePos.getX() - 1, basePos.getX() + data.getWidth(),
+                    basePos.getY() - 1, basePos.getY() + data.getHeight(),
+                    basePos.getZ() - 1, basePos.getZ() + data.getLength());
+        } else {
+            beginPhaseChunk(cp, basePos.getX(), basePos.getX() + data.getWidth() - 1,
+                    basePos.getY(), basePos.getY() + data.getHeight() - 1,
+                    basePos.getZ(), basePos.getZ() + data.getLength() - 1);
+        }
+    }
+
+    private void tickCleanup(int globalLimit) {
+        int writeBudget = blocksPerTick;
+        int scanBudget = blocksPerTick * cleanupScanMultiplier;
+        int globalScanBudget = (globalLimit == Integer.MAX_VALUE) ? Integer.MAX_VALUE : globalLimit * cleanupScanMultiplier;
+        int scanned = 0;
+        int written = 0;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        while (scanned < scanBudget && scanned < globalScanBudget && written < writeBudget) {
+            if (!phaseChunkActive) return;
+            cursor.set(phaseCurX, phaseCurY, phaseCurZ);
+            if (shouldCleanCell(phaseCurX, phaseCurY, phaseCurZ)) {
+                BlockState worldState = level.getBlockState(cursor);
+                if (!worldState.isAir() && isCleanupTarget(phaseCurX, phaseCurY, phaseCurZ, worldState)) {
+                    level.setBlock(cursor, AIR_STATE, Block.UPDATE_CLIENTS);
+                    written++;
+                }
+            }
+            scanned++;
+            if (!advanceWithinPhaseChunk()) {
+                finishCurrentChunk(false);
+                if (chunkQueue.isEmpty()) {
+                    advancePhase();
+                } else {
+                    state = State.CLEAN_PRELOAD;
+                }
+                return;
+            }
+        }
+    }
+
+    private boolean shouldCleanCell(int wx, int wy, int wz) {
+        boolean inside = !isOnShellLayer(wx, wy, wz);
+        if (inside) {
+            int sx = wx - basePos.getX();
+            int sy = wy - basePos.getY();
+            int sz = wz - basePos.getZ();
+            BlockState schemState = data.getBlockAt(currentPos.set(sx, sy, sz), AIR_STATE);
+            return schemState.isAir();
+        }
+        return sealEnabled && removeShell;
+    }
+
+    private boolean isCleanupTarget(int wx, int wy, int wz, BlockState worldState) {
+        boolean onShell = isOnShellLayer(wx, wy, wz);
+        if (onShell) {
+            return worldState.is(SHELL_STATE.getBlock());
+        }
+        if (sealEnabled && removeShell && worldState.is(SHELL_STATE.getBlock())) {
+            return true;
+        }
+        if (cleanupFluidsEnabled && (worldState.is(Blocks.WATER) || worldState.is(Blocks.LAVA))) {
+            return true;
+        }
+        if (cleanupFallingEnabled && worldState.getBlock() instanceof FallingBlock) {
+            return true;
+        }
+        return false;
+    }
+
+    private void beginPhaseChunk(ChunkPos cp, int wMinX, int wMaxX, int wMinY, int wMaxY, int wMinZ, int wMaxZ) {
+        phaseMinX = Math.max(cp.x * 16, wMinX);
+        phaseMaxX = Math.min(cp.x * 16 + 15, wMaxX);
+        phaseMinZ = Math.max(cp.z * 16, wMinZ);
+        phaseMaxZ = Math.min(cp.z * 16 + 15, wMaxZ);
+        phaseMinY = Math.max(wMinY, level.getMinBuildHeight());
+        phaseMaxY = Math.min(wMaxY, level.getMaxBuildHeight() - 1);
+        phaseCurX = phaseMinX;
+        phaseCurY = phaseMinY;
+        phaseCurZ = phaseMinZ;
+    }
+
+    private boolean advanceWithinPhaseChunk() {
+        phaseCurX++;
+        if (phaseCurX > phaseMaxX) {
+            phaseCurX = phaseMinX;
+            phaseCurZ++;
+            if (phaseCurZ > phaseMaxZ) {
+                phaseCurZ = phaseMinZ;
+                phaseCurY++;
+                if (phaseCurY > phaseMaxY) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @SuppressWarnings("unchecked")
@@ -260,7 +502,7 @@ public class SchematicPasteWorker {
                 CompoundTag schemTag = NbtIo.readCompressed(in);
                 data = SchematicData.load(server.registryAccess(), schemTag);
                 blocksPerTick = perTick ? speed : data.getTotalBlockCount() / speed;
-                state = State.PRELOAD;
+                state = nextStateAfterLoading();
             } catch (IOException e) {
                 SchematicPasteManager.LOGGER.error("can't open resource {}: {}", location, e.getMessage());
                 fail("Schematic %s can't be read: %s", location, e.getMessage());
@@ -269,6 +511,18 @@ public class SchematicPasteWorker {
             SchematicPasteManager.LOGGER.error("unknown resource {}", location);
             fail("Resource %s does not exist in resource manager", location);
         }));
+    }
+
+    private State nextStateAfterLoading() {
+        String hint = resumePhaseHint;
+        resumePhaseHint = null;
+        if ("CLEANING".equals(hint)) {
+            return cleanupEnabled() ? State.CLEAN_PRELOAD : State.FINISHED;
+        }
+        if ("PASTING".equals(hint)) {
+            return State.PRELOAD;
+        }
+        return sealEnabled ? State.SEAL_PRELOAD : State.PRELOAD;
     }
 
     public State getState() {
@@ -326,8 +580,12 @@ public class SchematicPasteWorker {
     public enum State {
         INIT(true),
         LOADING(true),
+        SEAL_PRELOAD(true),
+        SEALING(true),
         PRELOAD(true),
         PASTING(true),
+        CLEAN_PRELOAD(true),
+        CLEANING(true),
         FAILED(false),
         FINISHED(false),
         CANCELLED(false);

--- a/src/main/java/dev/ftb/packcompanion/features/schematic/SchematicPasteWorker.java
+++ b/src/main/java/dev/ftb/packcompanion/features/schematic/SchematicPasteWorker.java
@@ -6,6 +6,7 @@ import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
@@ -36,7 +37,7 @@ import java.util.function.Consumer;
 
 public class SchematicPasteWorker {
     private static final BlockState AIR_STATE = Blocks.AIR.defaultBlockState();
-    private static final BlockState SHELL_STATE = Blocks.BEDROCK.defaultBlockState();
+    private static final String DEFAULT_SHELL_BLOCK_ID = "minecraft:barrier";
 
     private final ResourceLocation location;
     private final BlockPos basePos;
@@ -67,6 +68,9 @@ public class SchematicPasteWorker {
     private boolean cleanupFallingEnabled;
     private boolean removeShell;
     private int cleanupScanMultiplier;
+    private String shellBlockId;
+    private BlockState shellState;
+    private int shellFace;
 
     public SchematicPasteWorker(@Nullable CommandSourceStack sourceStack, ResourceLocation location, Either<ServerLevel,ResourceLocation> levelOrDimensionId, BlockPos basePos, int speed, boolean perTick) {
         this.sourceStack = sourceStack;
@@ -102,6 +106,7 @@ public class SchematicPasteWorker {
             worker.cleanupFallingEnabled = c.getBoolean("cleanupFallingEnabled");
             worker.removeShell = c.getBoolean("removeShell");
             worker.cleanupScanMultiplier = c.contains("cleanupScanMultiplier") ? c.getInt("cleanupScanMultiplier") : 20;
+            worker.shellBlockId = c.contains("shellBlockId") ? c.getString("shellBlockId") : DEFAULT_SHELL_BLOCK_ID;
             worker.configSnapshotLoaded = true;
             return Optional.of(worker);
         }
@@ -125,6 +130,7 @@ public class SchematicPasteWorker {
             tag.putBoolean("cleanupFallingEnabled", cleanupFallingEnabled);
             tag.putBoolean("removeShell", removeShell);
             tag.putInt("cleanupScanMultiplier", cleanupScanMultiplier);
+            if (shellBlockId != null) tag.putString("shellBlockId", shellBlockId);
         });
     }
 
@@ -153,7 +159,9 @@ public class SchematicPasteWorker {
                     cleanupFallingEnabled = PCServerConfig.SCHEMATIC_CLEANUP_FALLING_BLOCKS.get();
                     removeShell = PCServerConfig.SCHEMATIC_REMOVE_SHELL_AFTER_PASTE.get();
                     cleanupScanMultiplier = PCServerConfig.SCHEMATIC_CLEANUP_SCAN_MULTIPLIER.get();
+                    shellBlockId = PCServerConfig.SCHEMATIC_SHELL_BLOCK.get();
                 }
+                shellState = resolveShellState(shellBlockId);
                 state = State.LOADING;
                 loadSchematicDataAsync(server);
             }
@@ -307,9 +315,8 @@ public class SchematicPasteWorker {
     }
 
     private void beginShellChunk(ChunkPos cp) {
-        beginPhaseChunk(cp, basePos.getX() - 1, basePos.getX() + data.getWidth(),
-                basePos.getY() - 1, basePos.getY() + data.getHeight(),
-                basePos.getZ() - 1, basePos.getZ() + data.getLength());
+        shellFace = 0;
+        setupShellFace(cp);
     }
 
     private void tickShell(int globalLimit) {
@@ -317,21 +324,122 @@ public class SchematicPasteWorker {
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
         while (placed < blocksPerTick && placed < globalLimit) {
             if (!phaseChunkActive) return;
-            cursor.set(phaseCurX, phaseCurY, phaseCurZ);
-            if (isOnShellLayer(phaseCurX, phaseCurY, phaseCurZ)) {
-                level.setBlock(cursor, SHELL_STATE, Block.UPDATE_CLIENTS);
-                placed++;
-            }
-            if (!advanceWithinPhaseChunk()) {
-                finishCurrentChunk(false);
-                if (chunkQueue.isEmpty()) {
-                    advancePhase();
-                } else {
-                    state = State.SEAL_PRELOAD;
-                }
+            if (shellFace >= 6) {
+                finishShellChunk();
                 return;
             }
+            cursor.set(phaseCurX, phaseCurY, phaseCurZ);
+            level.setBlock(cursor, shellState, Block.UPDATE_CLIENTS);
+            placed++;
+            if (!advanceWithinPhaseChunk()) {
+                shellFace++;
+                ChunkPos cp = chunkQueue.peek();
+                if (cp == null || !setupShellFace(cp)) {
+                    finishShellChunk();
+                    return;
+                }
+            }
         }
+    }
+
+    private void finishShellChunk() {
+        finishCurrentChunk(false);
+        if (chunkQueue.isEmpty()) {
+            advancePhase();
+        } else {
+            state = State.SEAL_PRELOAD;
+        }
+    }
+
+    private boolean setupShellFace(ChunkPos cp) {
+        int boxMinX = basePos.getX() - 1;
+        int boxMaxX = basePos.getX() + data.getWidth();
+        int boxMinY = basePos.getY() - 1;
+        int boxMaxY = basePos.getY() + data.getHeight();
+        int boxMinZ = basePos.getZ() - 1;
+        int boxMaxZ = basePos.getZ() + data.getLength();
+
+        int cMinX = Math.max(cp.x * 16, boxMinX);
+        int cMaxX = Math.min(cp.x * 16 + 15, boxMaxX);
+        int cMinZ = Math.max(cp.z * 16, boxMinZ);
+        int cMaxZ = Math.min(cp.z * 16 + 15, boxMaxZ);
+
+        int worldMinY = level.getMinBuildHeight();
+        int worldMaxY = level.getMaxBuildHeight() - 1;
+        int wallMinY = Math.max(boxMinY + 1, worldMinY);
+        int wallMaxY = Math.min(boxMaxY - 1, worldMaxY);
+
+        while (shellFace < 6) {
+            boolean ok = false;
+            switch (shellFace) {
+                case 0 -> {
+                    if (boxMinY >= worldMinY && boxMinY <= worldMaxY) {
+                        setPhaseBounds(cMinX, cMaxX, boxMinY, boxMinY, cMinZ, cMaxZ);
+                        ok = true;
+                    }
+                }
+                case 1 -> {
+                    if (boxMaxY >= worldMinY && boxMaxY <= worldMaxY) {
+                        setPhaseBounds(cMinX, cMaxX, boxMaxY, boxMaxY, cMinZ, cMaxZ);
+                        ok = true;
+                    }
+                }
+                case 2 -> {
+                    if (boxMinZ >= cMinZ && boxMinZ <= cMaxZ && wallMinY <= wallMaxY) {
+                        setPhaseBounds(cMinX, cMaxX, wallMinY, wallMaxY, boxMinZ, boxMinZ);
+                        ok = true;
+                    }
+                }
+                case 3 -> {
+                    if (boxMaxZ >= cMinZ && boxMaxZ <= cMaxZ && wallMinY <= wallMaxY) {
+                        setPhaseBounds(cMinX, cMaxX, wallMinY, wallMaxY, boxMaxZ, boxMaxZ);
+                        ok = true;
+                    }
+                }
+                case 4 -> {
+                    if (boxMinX >= cMinX && boxMinX <= cMaxX && wallMinY <= wallMaxY) {
+                        int innerMinZ = Math.max(boxMinZ + 1, cMinZ);
+                        int innerMaxZ = Math.min(boxMaxZ - 1, cMaxZ);
+                        if (innerMinZ <= innerMaxZ) {
+                            setPhaseBounds(boxMinX, boxMinX, wallMinY, wallMaxY, innerMinZ, innerMaxZ);
+                            ok = true;
+                        }
+                    }
+                }
+                case 5 -> {
+                    if (boxMaxX >= cMinX && boxMaxX <= cMaxX && wallMinY <= wallMaxY) {
+                        int innerMinZ = Math.max(boxMinZ + 1, cMinZ);
+                        int innerMaxZ = Math.min(boxMaxZ - 1, cMaxZ);
+                        if (innerMinZ <= innerMaxZ) {
+                            setPhaseBounds(boxMaxX, boxMaxX, wallMinY, wallMaxY, innerMinZ, innerMaxZ);
+                            ok = true;
+                        }
+                    }
+                }
+            }
+            if (ok) return true;
+            shellFace++;
+        }
+        return false;
+    }
+
+    private void setPhaseBounds(int minX, int maxX, int minY, int maxY, int minZ, int maxZ) {
+        phaseMinX = minX; phaseMaxX = maxX;
+        phaseMinY = minY; phaseMaxY = maxY;
+        phaseMinZ = minZ; phaseMaxZ = maxZ;
+        phaseCurX = minX; phaseCurY = minY; phaseCurZ = minZ;
+    }
+
+    private BlockState resolveShellState(String id) {
+        ResourceLocation loc = id != null ? ResourceLocation.tryParse(id) : null;
+        if (loc != null) {
+            Block block = BuiltInRegistries.BLOCK.getOptional(loc).orElse(null);
+            if (block != null && block != Blocks.AIR) {
+                return block.defaultBlockState();
+            }
+        }
+        SchematicPasteManager.LOGGER.warn("invalid schematic shell_block '{}', falling back to {}", id, DEFAULT_SHELL_BLOCK_ID);
+        return Blocks.BARRIER.defaultBlockState();
     }
 
     private boolean isOnShellLayer(int wx, int wy, int wz) {
@@ -406,9 +514,9 @@ public class SchematicPasteWorker {
     private boolean isCleanupTarget(int wx, int wy, int wz, BlockState worldState) {
         boolean onShell = isOnShellLayer(wx, wy, wz);
         if (onShell) {
-            return worldState.is(SHELL_STATE.getBlock());
+            return worldState.is(shellState.getBlock());
         }
-        if (sealEnabled && removeShell && worldState.is(SHELL_STATE.getBlock())) {
+        if (sealEnabled && removeShell && worldState.is(shellState.getBlock())) {
             return true;
         }
         if (cleanupFluidsEnabled && (worldState.is(Blocks.WATER) || worldState.is(Blocks.LAVA))) {


### PR DESCRIPTION
Added a new server configurations and worker logic to enhance schematic pasting:
- Before pasting, an optional bedrock shell can be created around the schematic's bounding box to prevent external fluids and falling blocks from interfering.
- After pasting, optional cleanup scans can remove stray fluids (water/lava) and falling blocks (sand/gravel/concrete powder) that leaked into or fell into the pasted area.
- The bedrock shell can optionally be removed during cleanup.
- Configurable cleanup scan multiplier allows adjusting performance impact.